### PR TITLE
Set Ubuntu version to 16.04 to fix compatibility problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:16.04
 RUN apt update && apt install python python-bs4 python-numpy python-opencv python-html5lib vim git -y && rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/zzh1996/ustc-grade-automatic-notification.git
 WORKDIR ustc-grade-automatic-notification


### PR DESCRIPTION
Dockerfile 中如果使用目前最新版本的 Ubuntu 的话会有两个问题：

1. `debconf` 在配置 `tzdata` 包的时候会回退到 `Readline` 前端，但是无法操作，需要先 `export DEBIAN_FRONTEND=noninteractive`

2. 程序报错 `Error: 'module' object has no attribute 'KNearest'`

所以做了一点小改动，避免兼容性问题给用户的困扰。